### PR TITLE
update log4j2, log nanos

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,12 +17,12 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
-            <version>2.11.2</version>
+            <version>2.12.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-slf4j-impl</artifactId>
-            <version>2.11.2</version>
+            <version>2.12.0</version>
         </dependency>
         <dependency>
             <groupId>net.jcip</groupId>

--- a/src/main/resources/log4j2.xml
+++ b/src/main/resources/log4j2.xml
@@ -2,7 +2,7 @@
 <Configuration status="WARN" strict="true">
     <Appenders>
         <Appender type="Console" name="STDOUT">
-            <Layout type="PatternLayout" pattern="%-5p [%t][%d{UNIX_MILLIS}]: %m%n"/>
+            <Layout type="PatternLayout" pattern="%-5p [%t][%d{dd MMM yyyy HH:mm:ss,nnnnnnn}]: %m%n"/>
         </Appender>
     </Appenders>
 


### PR DESCRIPTION
* https://issues.apache.org/jira/browse/LOG4J2-1883

log at nanosecond precision! it's 1000 x better than microsecond precision which is 1000x better than millisecond precision.

on my windows 10 machine, only 100s of nanoseconds were captured, but this is still a 1000x improvement.

needed for debugging issues with the delay toggler.