### PR TITLE
Add slot manager

### DIFF
--- a/src/main/java/name/maxdeliso/micron/looper/SingleThreadedStreamingEventLooper.java
+++ b/src/main/java/name/maxdeliso/micron/looper/SingleThreadedStreamingEventLooper.java
@@ -3,16 +3,6 @@ package name.maxdeliso.micron.looper;
 import com.codahale.metrics.Gauge;
 import com.codahale.metrics.Meter;
 import com.codahale.metrics.MetricRegistry;
-import lombok.extern.slf4j.Slf4j;
-import name.maxdeliso.micron.looper.read.SerialReadHandler;
-import name.maxdeliso.micron.looper.toggle.DelayedToggle;
-import name.maxdeliso.micron.looper.toggle.SelectionKeyToggleQueueAdder;
-import name.maxdeliso.micron.looper.write.SerialBufferingWriteHandler;
-import name.maxdeliso.micron.message.RingBufferMessageStore;
-import name.maxdeliso.micron.peer.PeerRegistry;
-import name.maxdeliso.micron.selector.NonBlockingAcceptorSelector;
-import name.maxdeliso.micron.selector.PeerCountingReadWriteSelector;
-
 import java.io.IOException;
 import java.net.SocketAddress;
 import java.nio.ByteBuffer;
@@ -24,10 +14,18 @@ import java.nio.channels.spi.SelectorProvider;
 import java.nio.charset.Charset;
 import java.time.Duration;
 import java.util.Optional;
-import java.util.Random;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.DelayQueue;
 import java.util.concurrent.atomic.AtomicReference;
+import lombok.extern.slf4j.Slf4j;
+import name.maxdeliso.micron.looper.read.SerialReadHandler;
+import name.maxdeliso.micron.looper.toggle.DelayedToggle;
+import name.maxdeliso.micron.looper.toggle.SelectionKeyToggleQueueAdder;
+import name.maxdeliso.micron.looper.write.SerialBufferingWriteHandler;
+import name.maxdeliso.micron.message.RingBufferMessageStore;
+import name.maxdeliso.micron.peer.PeerRegistry;
+import name.maxdeliso.micron.selector.NonBlockingAcceptorSelector;
+import name.maxdeliso.micron.selector.PeerCountingReadWriteSelector;
 
 @Slf4j
 public class SingleThreadedStreamingEventLooper implements
@@ -49,22 +47,21 @@ public class SingleThreadedStreamingEventLooper implements
   private final SelectionKeyToggleQueueAdder selectionKeyToggleQueueAdder;
   private final SerialReadHandler readHandler;
   private final SerialBufferingWriteHandler writeHandler;
-  private final MetricRegistry metrics;
 
   private final Meter events;
 
   /**
    * Build a single threaded threaded streaming event looper.
-   * @param socketAddress address to listen on.
-   * @param messageCharset message charset to use.
-   * @param peerRegistry a peer registry instance.
-   * @param messageStore a message store instance.
-   * @param selectorProvider a provider of selectors.
-   * @param incomingBuffer a single shared buffer for incoming messages.
-   * @param toggleDelayQueue a delay queue of toggle events.
+   *
+   * @param socketAddress       address to listen on.
+   * @param messageCharset      message charset to use.
+   * @param peerRegistry        a peer registry instance.
+   * @param messageStore        a message store instance.
+   * @param selectorProvider    a provider of selectors.
+   * @param incomingBuffer      a single shared buffer for incoming messages.
+   * @param toggleDelayQueue    a delay queue of toggle events.
    * @param asyncEnableDuration the duration to re-enable i/o operations for.
-   * @param metrics capture metrics about performance.
-   * @param random an RNG.
+   * @param metrics             capture metrics about performance.
    */
   public SingleThreadedStreamingEventLooper(final SocketAddress socketAddress,
                                             final Charset messageCharset,
@@ -74,22 +71,19 @@ public class SingleThreadedStreamingEventLooper implements
                                             final ByteBuffer incomingBuffer,
                                             final DelayQueue<DelayedToggle> toggleDelayQueue,
                                             final Duration asyncEnableDuration,
-                                            final MetricRegistry metrics,
-                                            final Random random) {
+                                            final MetricRegistry metrics) {
     this.socketAddress = socketAddress;
     this.peerRegistry = peerRegistry;
     this.selectorProvider = selectorProvider;
-    this.metrics = metrics;
 
-    this.events = this.metrics.meter("events");
+    this.events = metrics.meter("events");
 
     metrics.register("peers", (Gauge<Long>) peerRegistry::size);
 
     this.selectionKeyToggleQueueAdder = new SelectionKeyToggleQueueAdder(
         asyncEnableDuration,
         selectorRef,
-        toggleDelayQueue,
-        random);
+        toggleDelayQueue);
 
     this.readHandler = new SerialReadHandler(
         incomingBuffer,
@@ -132,6 +126,19 @@ public class SingleThreadedStreamingEventLooper implements
           }
 
           if (selectedKey.isValid()
+              && selectedKey.isReadable()
+              && ((selectedKey.interestOps() & SelectionKey.OP_READ) == SelectionKey.OP_READ)) {
+            handleReadableKey(
+                selectedKey,
+                peerRegistry,
+                peer -> {
+                  if (!readHandler.handleReadablePeer(selectedKey, peer)) {
+                    log.trace("no message read from peer: {}", peer);
+                  }
+                });
+          }
+
+          if (selectedKey.isValid()
               && selectedKey.isWritable()
               && ((selectedKey.interestOps() & SelectionKey.OP_WRITE) == SelectionKey.OP_WRITE)) {
             handleWritableKey(
@@ -143,19 +150,6 @@ public class SingleThreadedStreamingEventLooper implements
                   }
                 }
             );
-          }
-
-          if (selectedKey.isValid()
-              && selectedKey.isReadable()
-              && ((selectedKey.interestOps() & SelectionKey.OP_READ) == SelectionKey.OP_READ)) {
-            handleReadableKey(
-                selectedKey,
-                peerRegistry,
-                peer -> {
-                  if (!readHandler.handleReadablePeer(selectedKey, peer)) {
-                    log.trace("no message read from peer: {}", peer);
-                  }
-                });
           }
         } // for
 
@@ -188,6 +182,8 @@ public class SingleThreadedStreamingEventLooper implements
           log.warn("select ref was absent during halt...");
         });
 
+    log.info("awaiting countdown latch");
     latch.await();
+    log.info("halt completed");
   }
 }

--- a/src/main/java/name/maxdeliso/micron/looper/read/ReadHandler.java
+++ b/src/main/java/name/maxdeliso/micron/looper/read/ReadHandler.java
@@ -1,8 +1,7 @@
 package name.maxdeliso.micron.looper.read;
 
-import name.maxdeliso.micron.peer.Peer;
-
 import java.nio.channels.SelectionKey;
+import name.maxdeliso.micron.peer.Peer;
 
 public interface ReadHandler {
   boolean handleReadablePeer(final SelectionKey key, final Peer peer);

--- a/src/main/java/name/maxdeliso/micron/looper/read/SerialReadHandler.java
+++ b/src/main/java/name/maxdeliso/micron/looper/read/SerialReadHandler.java
@@ -1,17 +1,16 @@
 package name.maxdeliso.micron.looper.read;
 
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.SelectionKey;
+import java.nio.charset.Charset;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import name.maxdeliso.micron.looper.toggle.SelectionKeyToggleQueueAdder;
 import name.maxdeliso.micron.message.RingBufferMessageStore;
 import name.maxdeliso.micron.peer.Peer;
 import name.maxdeliso.micron.peer.PeerRegistry;
-
-import java.io.IOException;
-import java.nio.ByteBuffer;
-import java.nio.channels.SelectionKey;
-import java.nio.charset.Charset;
-import java.util.Optional;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -46,10 +45,7 @@ public class SerialReadHandler implements ReadHandler {
 
     selectionKeyToggleQueueAdder.disableAndEnqueueEnable(key, SelectionKey.OP_READ);
 
-    return Optional
-        .ofNullable(incoming)
-        .map(messageStore::add)
-        .orElse(false);
+    return Optional.ofNullable(incoming).map(messageStore::add).orElse(false);
   }
 
   private PeerReadResult performRead(final Peer peer) {
@@ -87,10 +83,6 @@ public class SerialReadHandler implements ReadHandler {
       }
     }
 
-    return PeerReadResult
-        .builder()
-        .bytesReadTotal(bytesReadTotal)
-        .readCalls(readCalls)
-        .build();
+    return PeerReadResult.builder().bytesReadTotal(bytesReadTotal).readCalls(readCalls).build();
   }
 }

--- a/src/main/java/name/maxdeliso/micron/looper/toggle/DelayedToggler.java
+++ b/src/main/java/name/maxdeliso/micron/looper/toggle/DelayedToggler.java
@@ -1,8 +1,7 @@
 package name.maxdeliso.micron.looper.toggle;
 
-import lombok.extern.slf4j.Slf4j;
-
 import java.util.concurrent.DelayQueue;
+import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 public class DelayedToggler implements Runnable {

--- a/src/main/java/name/maxdeliso/micron/looper/toggle/SelectionKeyToggleQueueAdder.java
+++ b/src/main/java/name/maxdeliso/micron/looper/toggle/SelectionKeyToggleQueueAdder.java
@@ -1,16 +1,13 @@
 package name.maxdeliso.micron.looper.toggle;
 
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-
 import java.nio.channels.CancelledKeyException;
 import java.nio.channels.SelectionKey;
 import java.nio.channels.Selector;
 import java.time.Duration;
-import java.util.Random;
 import java.util.concurrent.DelayQueue;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -19,7 +16,6 @@ public class SelectionKeyToggleQueueAdder implements ToggleQueueAdder {
   private final Duration enableDuration;
   private final AtomicReference<Selector> selectorAtomicReference;
   private final DelayQueue<DelayedToggle> toggleDelayQueue;
-  private final Random random;
 
   @Override
   public void disableAndEnqueueEnable(final SelectionKey key, final int mask) {
@@ -38,11 +34,9 @@ public class SelectionKeyToggleQueueAdder implements ToggleQueueAdder {
   public void enqueueEnable(final SelectionKey key, final int mask) {
     var delayedEnableToggle = new DelayedToggle(
         selectorAtomicReference,
-        enableDuration.getNano(),
-        TimeUnit.NANOSECONDS,
+        enableDuration,
         key,
-        mask,
-        random);
+        mask);
 
     toggleDelayQueue.add(delayedEnableToggle);
   }

--- a/src/main/java/name/maxdeliso/micron/looper/write/SerialBufferingWriteHandler.java
+++ b/src/main/java/name/maxdeliso/micron/looper/write/SerialBufferingWriteHandler.java
@@ -1,16 +1,15 @@
 package name.maxdeliso.micron.looper.write;
 
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.SelectionKey;
+import java.nio.charset.Charset;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import name.maxdeliso.micron.looper.toggle.SelectionKeyToggleQueueAdder;
 import name.maxdeliso.micron.message.RingBufferMessageStore;
 import name.maxdeliso.micron.peer.Peer;
 import name.maxdeliso.micron.peer.PeerRegistry;
-
-import java.io.IOException;
-import java.nio.ByteBuffer;
-import java.nio.channels.SelectionKey;
-import java.nio.charset.Charset;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -24,16 +23,25 @@ public class SerialBufferingWriteHandler implements WriteHandler {
   @Override
   public boolean handleWritablePeer(final SelectionKey key, final Peer peer) {
     if (peer.position() == messageStore.position()) {
-      log.trace("nothing to write, peer is caught up");
+      log.trace("nothing to write, peer {} is caught up", peer);
       return false;
     }
 
     try {
-      final var messageToWrite = messageStore.get(peer.position());
+      final var messageToWriteOpt = messageStore.get(peer.position());
+      final var newPosition = peer.advancePosition();
+
+      log.trace("updated the position of peer {} position to {}", peer, newPosition);
+
+      if (messageToWriteOpt.isEmpty()) {
+        log.trace("nothing to write, message store is empty at position {}", peer.position());
+        return false;
+      }
+
+      final var messageToWrite = messageToWriteOpt.get();
       final var bytesToWrite = messageToWrite.getBytes(charset);
       final var bufferToWrite = ByteBuffer.wrap(bytesToWrite);
       final var bytesWritten = peer.getSocketChannel().write(bufferToWrite);
-      final var newPosition = peer.advancePosition(messageStore.size());
 
       log.trace("wrote {} bytes to peer {} to advance to {}", bytesWritten, peer, newPosition);
 

--- a/src/main/java/name/maxdeliso/micron/looper/write/WriteHandler.java
+++ b/src/main/java/name/maxdeliso/micron/looper/write/WriteHandler.java
@@ -1,8 +1,7 @@
 package name.maxdeliso.micron.looper.write;
 
-import name.maxdeliso.micron.peer.Peer;
-
 import java.nio.channels.SelectionKey;
+import name.maxdeliso.micron.peer.Peer;
 
 public interface WriteHandler {
   boolean handleWritablePeer(final SelectionKey key, final Peer peer);

--- a/src/main/java/name/maxdeliso/micron/message/RingBufferMessageStore.java
+++ b/src/main/java/name/maxdeliso/micron/message/RingBufferMessageStore.java
@@ -1,9 +1,11 @@
 package name.maxdeliso.micron.message;
 
+import java.util.Optional;
+
 public interface RingBufferMessageStore {
   boolean add(String received);
 
-  String get(int messageIdx);
+  Optional<String> get(int messageIdx);
 
   int position();
 

--- a/src/main/java/name/maxdeliso/micron/peer/PeerRegistry.java
+++ b/src/main/java/name/maxdeliso/micron/peer/PeerRegistry.java
@@ -8,8 +8,6 @@ public interface PeerRegistry {
 
   Peer allocatePeer(SocketChannel clientChannel);
 
-  boolean positionOccupied(int pos);
-
   void evictPeer(Peer peer);
 
   long size();

--- a/src/main/java/name/maxdeliso/micron/peer/RingPositionTracker.java
+++ b/src/main/java/name/maxdeliso/micron/peer/RingPositionTracker.java
@@ -1,7 +1,7 @@
 package name.maxdeliso.micron.peer;
 
 public interface RingPositionTracker {
-  int advancePosition(final int max);
+  int advancePosition();
 
   int position();
 }

--- a/src/main/java/name/maxdeliso/micron/selector/NonBlockingAcceptorSelector.java
+++ b/src/main/java/name/maxdeliso/micron/selector/NonBlockingAcceptorSelector.java
@@ -1,15 +1,14 @@
 package name.maxdeliso.micron.selector;
 
-import name.maxdeliso.micron.looper.toggle.SelectionKeyToggleQueueAdder;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import java.io.IOException;
 import java.nio.channels.SelectionKey;
 import java.nio.channels.Selector;
 import java.nio.channels.ServerSocketChannel;
 import java.nio.channels.SocketChannel;
 import java.util.function.BiConsumer;
+import name.maxdeliso.micron.looper.toggle.SelectionKeyToggleQueueAdder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public interface NonBlockingAcceptorSelector {
   /**

--- a/src/main/java/name/maxdeliso/micron/selector/PeerCountingReadWriteSelector.java
+++ b/src/main/java/name/maxdeliso/micron/selector/PeerCountingReadWriteSelector.java
@@ -1,13 +1,12 @@
 package name.maxdeliso.micron.selector;
 
-import name.maxdeliso.micron.peer.Peer;
-import name.maxdeliso.micron.peer.PeerRegistry;
-
 import java.nio.channels.SelectionKey;
 import java.nio.channels.SocketChannel;
 import java.util.Optional;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
+import name.maxdeliso.micron.peer.Peer;
+import name.maxdeliso.micron.peer.PeerRegistry;
 
 public interface PeerCountingReadWriteSelector {
   default void associatePeer(final SocketChannel socketChannel,

--- a/src/main/java/name/maxdeliso/micron/slots/InMemorySlotManager.java
+++ b/src/main/java/name/maxdeliso/micron/slots/InMemorySlotManager.java
@@ -1,0 +1,60 @@
+package name.maxdeliso.micron.slots;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class InMemorySlotManager implements SlotManager {
+  private final List<AtomicInteger> occupationCounts;
+
+  public InMemorySlotManager(int size) {
+    occupationCounts = new ArrayList<>(size);
+
+    for (int i = 0; i < size; i++) {
+      occupationCounts.add(new AtomicInteger(0));
+    }
+  }
+
+  @Override
+  public boolean positionOccupied(int pos) {
+    return occupationCounts.get(pos).get() > 0;
+  }
+
+  @Override
+  public void incrementOccupants(int pos) {
+    occupationCounts.get(pos).incrementAndGet();
+  }
+
+  @Override
+  public void decrementOccupants(int pos) {
+    occupationCounts.get(pos).decrementAndGet();
+  }
+
+  @Override
+  public int size() {
+    return occupationCounts.size();
+  }
+
+  @Override
+  public String toString() {
+    final StringBuilder sb = new StringBuilder();
+    int matches = 0;
+
+    for (int i = 0; i < occupationCounts.size(); i++) {
+      final AtomicInteger occupationCount = occupationCounts.get(i);
+
+      if (occupationCount.get() > 0) {
+        if (matches > 0) {
+          sb.append(", ");
+        }
+
+        sb.append(occupationCount.get());
+        sb.append(" @ ");
+        sb.append(i);
+        matches++;
+      }
+    }
+
+    return "InMemorySlotManager{occupationCounts=" + sb.toString() + '}';
+  }
+}

--- a/src/main/java/name/maxdeliso/micron/slots/SlotManager.java
+++ b/src/main/java/name/maxdeliso/micron/slots/SlotManager.java
@@ -1,0 +1,11 @@
+package name.maxdeliso.micron.slots;
+
+public interface SlotManager {
+  boolean positionOccupied(int pos);
+
+  void incrementOccupants(int pos);
+
+  void decrementOccupants(int pos);
+
+  int size();
+}

--- a/src/test/java/name/maxdeliso/micron/looper/SingleThreadedStreamingEventLooperTest.java
+++ b/src/test/java/name/maxdeliso/micron/looper/SingleThreadedStreamingEventLooperTest.java
@@ -1,7 +1,13 @@
 package name.maxdeliso.micron.looper;
 
-import com.codahale.metrics.Metric;
 import com.codahale.metrics.MetricRegistry;
+import java.io.IOException;
+import java.net.SocketAddress;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.concurrent.DelayQueue;
 import name.maxdeliso.micron.looper.toggle.DelayedToggle;
 import name.maxdeliso.micron.message.RingBufferMessageStore;
 import name.maxdeliso.micron.peer.PeerRegistry;
@@ -14,15 +20,6 @@ import org.mockito.junit.MockitoJUnitRunner;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.IOException;
-import java.net.SocketAddress;
-import java.nio.ByteBuffer;
-import java.nio.charset.StandardCharsets;
-import java.time.Duration;
-import java.util.Arrays;
-import java.util.Random;
-import java.util.concurrent.DelayQueue;
-
 @RunWith(MockitoJUnitRunner.class)
 public class SingleThreadedStreamingEventLooperTest {
   private static final Logger LOGGER = LoggerFactory.getLogger(SingleThreadedStreamingEventLooperTest.class);
@@ -31,19 +28,24 @@ public class SingleThreadedStreamingEventLooperTest {
 
   @Mock
   MetricRegistry metricRegistry;
-  @Mock
-  Random random;
-  private SingleThreadedStreamingEventLooper singleThreadedStreamingEventLooper;
+
   @Mock
   private SocketAddress socketAddress;
+
   @Mock
   private PeerRegistry peerRegistry;
+
   @Mock
   private RingBufferMessageStore messageStore;
+
   @Mock
   private DelayQueue<DelayedToggle> delayedToggles;
+
   private Duration duration;
+
   private TestSelectorProvider selectorProvider;
+
+  private SingleThreadedStreamingEventLooper singleThreadedStreamingEventLooper;
 
   @Before
   public void buildLooper() {
@@ -60,8 +62,7 @@ public class SingleThreadedStreamingEventLooperTest {
         ByteBuffer.allocateDirect(TEST_BUFFER_SIZE),
         delayedToggles,
         duration,
-        metricRegistry,
-        random
+        metricRegistry
     );
   }
 

--- a/src/test/java/name/maxdeliso/micron/peer/InMemoryPeerRegistryTest.java
+++ b/src/test/java/name/maxdeliso/micron/peer/InMemoryPeerRegistryTest.java
@@ -1,10 +1,13 @@
 package name.maxdeliso.micron.peer;
 
+import name.maxdeliso.micron.message.RingBufferMessageStore;
+import name.maxdeliso.micron.slots.SlotManager;
 import name.maxdeliso.micron.support.TestSelectorProvider;
 import name.maxdeliso.micron.support.TestSocketChannel;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
 import java.nio.channels.SocketChannel;
@@ -14,6 +17,7 @@ import java.util.Optional;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
 public class InMemoryPeerRegistryTest {
@@ -26,11 +30,20 @@ public class InMemoryPeerRegistryTest {
 
   private PeerRegistry peerRegistry;
 
+  @Mock
+  private SlotManager slotManager;
+
+  @Mock
+  private RingBufferMessageStore ringBufferMessageStore;
+
   @Before
   public void setup() {
+    when(slotManager.size()).thenReturn(MAX_MESSAGES);
+    when(ringBufferMessageStore.size()).thenReturn(MAX_MESSAGES);
+
     selectorProvider = new TestSelectorProvider();
     socketChannel = new TestSocketChannel(selectorProvider);
-    peerRegistry = new InMemoryPeerRegistry();
+    peerRegistry = new InMemoryPeerRegistry(slotManager, ringBufferMessageStore);
   }
 
   @Test
@@ -66,8 +79,8 @@ public class InMemoryPeerRegistryTest {
     final var firstPeer = peerRegistry.allocatePeer(socketChannel);
     final var secondPeer = peerRegistry.allocatePeer(socketChannel);
 
-    firstPeer.advancePosition(MAX_MESSAGES);
-    secondPeer.advancePosition(MAX_MESSAGES);
+    firstPeer.advancePosition();
+    secondPeer.advancePosition();
 
     final Optional<Peer> firstPeerOpt = peerRegistry.get(0);
     final Optional<Peer> secondPeerOpt = peerRegistry.get(1);


### PR DESCRIPTION
## Overview

Previously, in order to check whether a position was occupied when attempting to advance the ring buffer message store position to account for the receiving of a new message, micron would traverse all peer records to check for a conflict.

This was slow.

Also, there was a circular dependency where the message store needed the peer registry to determine when it was about to overwrite the message at a peer's position, and the peer registry needed a message store to determine what the initial position of a peer should be.

Both of these problems are addressed in this PR by adding a new class called a slot manager. A slot manager keeps track of all of the slots in the address space of the ring buffer. Internally, it is a list of integers. Each integer represents how many peers are at each slot. Multiple peers can share a slot (and this is normal), but the ring buffer can never advance to a non-empty slot.

The check for slot emptiness is now O(1), as the slot manager is queried at a particular position, and the integer at that position is compared to zero, which is very fast in comparison to what it was doing before. The downside is that the position information is duplicated between the slot manager and the peer classes. I haven't figured out a better way to organize this, yet.

This means that if one peer is slow, it will rate limit all connected peers, which is fine. I need to think of effective ways to gather stats on when slow peers are rate limiting the data transfer on a per peer basis, and then publish that as a metric.

The expected distribution of the non-empty slots is tightly grouped, as all connected peers should receive readable events that move their read head up to the current ring buffer message store when there are new messages. In particular, one new message arriving will cause n writes, one per connected peer (including the peer that wrote the message), and this will cause n increments and decrements of the occupant count, to zero out the previous head position, and fill the new head position. This gets printed to the log in trace mode, as a list of integers, though you may want to decrease the message count to make this easier to see.

## Testing Done

Basic unit test coverage, manual testing.